### PR TITLE
update peer dependancies due to typescript

### DIFF
--- a/projects/ngx-barcode6/package.json
+++ b/projects/ngx-barcode6/package.json
@@ -10,8 +10,6 @@
   "author": "Edgar Giese <edgar@egiese.de>",
   "keywords": [
     "Angular",
-    "Angular15",
-    "Angular16",
     "Angular17",
     "Angular18",
     "barcode",
@@ -22,8 +20,8 @@
     "url": "https://github.com/efgiese/ngx-barcode6/issues"
   },
   "peerDependencies": {
-    "@angular/common": ">=14.0.0 <19.0.0",
-    "@angular/core": ">=14.0.0 <19.0.0",
+    "@angular/common": ">=17.0.0 <19.0.0",
+    "@angular/core": ">=17.0.0 <19.0.0",
     "jsbarcode": "^3.11.6"
   },
   "dependencies": {


### PR DESCRIPTION
Due to the difference in typescript versions from 4.8 and 5.3 this package is not compatible for older Angular versions.